### PR TITLE
Add Help/About menu with version info

### DIFF
--- a/src/axe_usd/dcc/qt_compat.py
+++ b/src/axe_usd/dcc/qt_compat.py
@@ -27,6 +27,7 @@ QHBoxLayout = QtWidgets.QHBoxLayout
 QLabel = QtWidgets.QLabel
 QLineEdit = QtWidgets.QLineEdit
 QMessageBox = QtWidgets.QMessageBox
+QMenuBar = QtWidgets.QMenuBar
 QPushButton = QtWidgets.QPushButton
 QScrollArea = QtWidgets.QScrollArea
 QSizePolicy = QtWidgets.QSizePolicy
@@ -48,6 +49,7 @@ __all__ = [
     "QLabel",
     "QLineEdit",
     "QMessageBox",
+    "QMenuBar",
     "QPushButton",
     "QScrollArea",
     "QSizePolicy",

--- a/src/axe_usd/dcc/substance_plugin.py
+++ b/src/axe_usd/dcc/substance_plugin.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping, Optional, Protocol, Sequence, Tuple
 
+from ..version import get_version
 from .qt_compat import (
     QCheckBox,
     QDialog,
@@ -18,6 +19,7 @@ from .qt_compat import (
     QLabel,
     QLineEdit,
     QMessageBox,
+    QMenuBar,
     QPushButton,
     QScrollArea,
     QSizePolicy,
@@ -159,11 +161,19 @@ class USDExporterView(QDialog):
         self.setWindowTitle("USD Exporter")
         self.setWindowIcon(QIcon())
         self.setMinimumSize(520, 240)
+        self._plugin_version = get_version()
 
         root_layout = QVBoxLayout()
         root_layout.setContentsMargins(10, 10, 10, 10)
         root_layout.setSpacing(6)
         self.setLayout(root_layout)
+
+        menu_bar = QMenuBar()
+        menu_bar.setNativeMenuBar(False)
+        help_menu = menu_bar.addMenu("Help")
+        help_menu.addAction("Help", self._show_help)
+        help_menu.addAction("About", self._show_about)
+        root_layout.setMenuBar(menu_bar)
 
         title = QLabel("Axe USD Exporter")
         title_font = title.font()
@@ -298,6 +308,23 @@ class USDExporterView(QDialog):
         hint.setPalette(pal)
         hint.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Minimum)
         return hint
+
+    def _show_help(self) -> None:
+        """Show a short help dialog."""
+        message = (
+            "Export textures first, then the plugin writes USD next to the export folder.\n\n"
+            "Use <export_folder> to auto-insert the current texture export path."
+        )
+        QMessageBox.information(self, "Axe USD Exporter Help", message)
+
+    def _show_about(self) -> None:
+        """Show an about dialog with version details."""
+        message = (
+            f"Axe USD Exporter\n"
+            f"Version {self._plugin_version}\n\n"
+            "Exports Substance Painter textures to USD with supported render engines."
+        )
+        QMessageBox.information(self, "About Axe USD Exporter", message)
 
     def _browse_publish_directory(self) -> None:
         """Open a directory picker for the publish path."""

--- a/src/axe_usd/version.py
+++ b/src/axe_usd/version.py
@@ -1,0 +1,53 @@
+"""Version helpers for the Axe USD plugin."""
+from __future__ import annotations
+
+from importlib import metadata
+from pathlib import Path
+from typing import Optional
+import re
+
+
+def _version_from_pyproject() -> Optional[str]:
+    repo_root = Path(__file__).resolve().parents[2]
+    pyproject = repo_root / "pyproject.toml"
+    if not pyproject.exists():
+        return None
+    try:
+        content = pyproject.read_text(encoding="utf-8")
+    except Exception:
+        return None
+
+    in_project = False
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            in_project = stripped == "[project]"
+            continue
+        if not in_project or not stripped.startswith("version"):
+            continue
+        match = re.match(r'version\s*=\s*"([^"]+)"', stripped)
+        if match:
+            return match.group(1)
+    return None
+
+
+def get_version() -> str:
+    """Return the plugin version string with safe fallbacks."""
+    try:
+        from . import _version  # type: ignore
+
+        version = getattr(_version, "__version__", None)
+        if version:
+            return str(version)
+    except Exception:
+        pass
+
+    try:
+        return metadata.version("sp-usd-creator")
+    except Exception:
+        pass
+
+    return _version_from_pyproject() or "unknown"
+
+
+__all__ = ["get_version"]

--- a/tools/build_plugin.py
+++ b/tools/build_plugin.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+from typing import Optional
+import re
 import shutil
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -10,6 +12,30 @@ if not PACKAGE_SRC.exists():
     raise SystemExit(f"Package not found: {PACKAGE_SRC}")
 if not PLUGIN_SRC.exists():
     raise SystemExit(f"Plugin template not found: {PLUGIN_SRC}")
+
+
+def _read_project_version() -> Optional[str]:
+    pyproject = ROOT / "pyproject.toml"
+    if not pyproject.exists():
+        return None
+    try:
+        content = pyproject.read_text(encoding="utf-8")
+    except Exception:
+        return None
+
+    in_project = False
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            in_project = stripped == "[project]"
+            continue
+        if not in_project or not stripped.startswith("version"):
+            continue
+        match = re.match(r'version\s*=\s*"([^"]+)"', stripped)
+        if match:
+            return match.group(1)
+    return None
+
 
 if DIST_DIR.exists():
     shutil.rmtree(DIST_DIR)
@@ -27,5 +53,10 @@ shutil.copytree(
     plugin_dist / "axe_usd",
     ignore=shutil.ignore_patterns("__pycache__", "*.pyc", ".ruff_cache", ".pytest_cache"),
 )
+
+version = _read_project_version()
+if version:
+    version_path = plugin_dist / "axe_usd" / "_version.py"
+    version_path.write_text(f'__version__ = "{version}"\n', encoding="utf-8")
 
 print(f"Built plugin bundle at: {DIST_DIR}")


### PR DESCRIPTION
## Summary
- Add a Help/About menu to the USD Exporter dock with usage guidance.
- Embed the version into the packaged plugin bundle during builds.

## Changes
- src/axe_usd/dcc/substance_plugin.py: add a menu bar with Help/About actions and display the version string.
- src/axe_usd/version.py: resolve version from packaged _version.py, installed metadata, or pyproject.toml.
- 	ools/build_plugin.py: write xe_usd/_version.py into the bundle using the pyproject.toml version.
- src/axe_usd/dcc/qt_compat.py: export QMenuBar for PySide2/6 compatibility.

