### PR TITLE
Refine USD texture overrides and tests

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -52,6 +52,28 @@ The Substance Painter plugins folder should contain:
 4. Core exporter builds publish paths and delegates to USD writer.
 5. USD writer creates layers and shader networks.
 
+## Texture Format Overrides
+You can override texture formats per renderer by passing `texture_format_overrides` in
+`ExportSettings`. Keys are `usd_preview`, `arnold`, and `mtlx`, and values can be file
+extensions with or without a leading dot.
+
+Example:
+```python
+settings = ExportSettings(
+    usdpreview=True,
+    arnold=True,
+    materialx=True,
+    primitive_path="/ASSET",
+    publish_directory=Path("publish"),
+    save_geometry=False,
+    texture_format_overrides={
+        "usd_preview": "jpg",
+        "arnold": ".exr",
+        "mtlx": "png",
+    },
+)
+```
+
 ## Substance Painter Texture Context
 `on_post_export` receives a `context` object with a `textures` mapping shaped like:
 - `Dict[Tuple[str, str], List[str]]`

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -53,6 +53,7 @@ Tokens are matched as standalone words (non-alphanumeric boundaries), so unrelat
 ## Notes
 - USD Preview uses `metallic`, Arnold/MaterialX use `metalness`. The plugin normalizes this for you.
 - The publish directory can include `<export_folder>` to substitute the active texture export folder.
+- Advanced: per-renderer texture format overrides are available via the API (see `docs/DEVELOPER_GUIDE.md`).
 
 ## Troubleshooting
 - Plugin not showing up:

--- a/src/axe_usd/core/models.py
+++ b/src/axe_usd/core/models.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional
 
 
 @dataclass(frozen=True)
@@ -15,6 +15,7 @@ class ExportSettings:
         publish_directory: Output directory for USD layers.
         save_geometry: Whether to export mesh geometry.
         main_layer_name: Name of the main layer file.
+        texture_format_overrides: Optional per-renderer texture format overrides.
     """
 
     usdpreview: bool
@@ -24,6 +25,7 @@ class ExportSettings:
     publish_directory: Path
     save_geometry: bool
     main_layer_name: str = "main.usda"
+    texture_format_overrides: Optional[Dict[str, str]] = None
 
 
 @dataclass(frozen=True)

--- a/src/axe_usd/usd/pxr_writer.py
+++ b/src/axe_usd/usd/pxr_writer.py
@@ -37,6 +37,7 @@ class PxrUsdWriter:
             create_usd_preview=settings.usdpreview,
             create_arnold=settings.arnold,
             create_mtlx=settings.materialx,
+            texture_format_overrides=settings.texture_format_overrides,
         )
 
 

--- a/tests/test_usd_material_processor.py
+++ b/tests/test_usd_material_processor.py
@@ -5,6 +5,14 @@ pxr = pytest.importorskip("pxr")
 from axe_usd.usd import material_processor
 
 
+def _asset_path_value(input_attr):
+    value = input_attr.Get()
+    path = value.path if hasattr(value, "path") else value
+    if path is None:
+        return None
+    return str(path).replace("\\", "/")
+
+
 def test_create_shaded_asset_publish_creates_layers(tmp_path):
     """Ensure USD publish creates the expected layer files."""
     material_dict_list = [
@@ -31,3 +39,151 @@ def test_create_shaded_asset_publish_creates_layers(tmp_path):
     assert (tmp_path / "main.usda").exists()
     assert (tmp_path / "layers" / "layer_mats.usda").exists()
     assert (tmp_path / "layers" / "layer_assign.usda").exists()
+
+
+def test_usd_preview_texture_override_applies(tmp_path):
+    """Ensure usd preview textures honor per-renderer format overrides."""
+    material_dict_list = [
+        {
+            "basecolor": {
+                "mat_name": "MatA",
+                "path": "C:/tex/MatA_BaseColor.exr",
+            }
+        }
+    ]
+
+    material_processor.create_shaded_asset_publish(
+        material_dict_list=material_dict_list,
+        stage=None,
+        geo_file=None,
+        parent_path="/ASSET",
+        layer_save_path=str(tmp_path),
+        main_layer_name="main.usda",
+        create_usd_preview=True,
+        create_arnold=False,
+        create_mtlx=False,
+        texture_format_overrides={"usd_preview": "jpg"},
+    )
+
+    stage = pxr.Usd.Stage.Open(str(tmp_path / "main.usda"))
+    texture_prim = stage.GetPrimAtPath(
+        "/ASSET/material/mat_MatA_collect/UsdPreviewMaterial/UsdPreviewNodeGraph/basecolorTexture"
+    )
+    texture_shader = pxr.UsdShade.Shader(texture_prim)
+    assert _asset_path_value(texture_shader.GetInput("file")) == "C:/tex/MatA_BaseColor.jpg"
+
+
+def test_renderer_specific_format_overrides(tmp_path):
+    """Ensure per-renderer overrides apply to each network."""
+    material_dict_list = [
+        {
+            "basecolor": {
+                "mat_name": "MatA",
+                "path": "C:/tex/MatA_BaseColor.exr",
+            }
+        }
+    ]
+
+    material_processor.create_shaded_asset_publish(
+        material_dict_list=material_dict_list,
+        stage=None,
+        geo_file=None,
+        parent_path="/ASSET",
+        layer_save_path=str(tmp_path),
+        main_layer_name="main.usda",
+        create_usd_preview=True,
+        create_arnold=True,
+        create_mtlx=True,
+        texture_format_overrides={
+            "usd_preview": "jpg",
+            "arnold": "tif",
+            "mtlx": "png",
+        },
+    )
+
+    stage = pxr.Usd.Stage.Open(str(tmp_path / "main.usda"))
+
+    usd_preview_prim = stage.GetPrimAtPath(
+        "/ASSET/material/mat_MatA_collect/UsdPreviewMaterial/UsdPreviewNodeGraph/basecolorTexture"
+    )
+    usd_preview_shader = pxr.UsdShade.Shader(usd_preview_prim)
+    assert _asset_path_value(usd_preview_shader.GetInput("file")) == "C:/tex/MatA_BaseColor.jpg"
+
+    arnold_prim = stage.GetPrimAtPath("/ASSET/material/mat_MatA_collect/arnold_basecolorTexture")
+    arnold_shader = pxr.UsdShade.Shader(arnold_prim)
+    assert _asset_path_value(arnold_shader.GetInput("filename")) == "C:/tex/MatA_BaseColor.tif"
+
+    mtlx_prim = stage.GetPrimAtPath("/ASSET/material/mat_MatA_collect/mtlx_basecolorTexture")
+    mtlx_shader = pxr.UsdShade.Shader(mtlx_prim)
+    assert _asset_path_value(mtlx_shader.GetInput("file")) == "C:/tex/MatA_BaseColor.png"
+
+
+def test_mtlx_metalness_is_float(tmp_path):
+    """Ensure MaterialX metalness remains float through the network."""
+    material_dict_list = [
+        {
+            "metalness": {
+                "mat_name": "MatA",
+                "path": "C:/tex/MatA_Metalness.exr",
+            }
+        }
+    ]
+
+    material_processor.create_shaded_asset_publish(
+        material_dict_list=material_dict_list,
+        stage=None,
+        geo_file=None,
+        parent_path="/ASSET",
+        layer_save_path=str(tmp_path),
+        main_layer_name="main.usda",
+        create_usd_preview=False,
+        create_arnold=False,
+        create_mtlx=True,
+    )
+
+    stage = pxr.Usd.Stage.Open(str(tmp_path / "main.usda"))
+    image_prim = stage.GetPrimAtPath("/ASSET/material/mat_MatA_collect/mtlx_metalnessTexture")
+    image_shader = pxr.UsdShade.Shader(image_prim)
+    assert image_shader.GetIdAttr().Get() == "ND_image_float"
+
+    range_prim = stage.GetPrimAtPath("/ASSET/material/mat_MatA_collect/mtlx_metalnessRange")
+    range_shader = pxr.UsdShade.Shader(range_prim)
+    assert range_shader.GetIdAttr().Get() == "ND_range_float"
+    assert range_shader.GetInput("in").GetTypeName() == pxr.Sdf.ValueTypeNames.Float
+
+    std_prim = stage.GetPrimAtPath("/ASSET/material/mat_MatA_collect/mtlx_mtlxstandard_surface1")
+    std_shader = pxr.UsdShade.Shader(std_prim)
+    assert std_shader.GetInput("metalness").GetTypeName() == pxr.Sdf.ValueTypeNames.Float
+
+
+def test_assign_material_raises_for_non_material():
+    stage = pxr.Usd.Stage.CreateInMemory()
+    prim = stage.DefinePrim("/NotMaterial", "Xform")
+    assigner = material_processor.USDShaderAssign(stage)
+
+    with pytest.raises(ValueError):
+        assigner.assign_material_to_primitives(prim, [])
+
+
+def test_assign_material_binds_mesh():
+    stage = pxr.Usd.Stage.CreateInMemory()
+    material_processor.USDShaderCreate(
+        stage=stage,
+        material_name="MatA",
+        material_dict={
+            "basecolor": {"mat_name": "MatA", "path": "C:/tex/MatA_BaseColor.png"}
+        },
+        parent_primpath="/ASSET/material",
+        create_usd_preview=True,
+        create_arnold=False,
+        create_mtlx=False,
+    )
+    mesh = pxr.UsdGeom.Mesh.Define(stage, "/ASSET/mesh/Mesh_MatA")
+
+    material_processor.USDShaderAssign(stage).run(
+        mats_parent_path="/ASSET/material",
+        mesh_parent_path="/ASSET",
+    )
+
+    binding = pxr.UsdShade.MaterialBindingAPI(mesh).GetDirectBinding().GetMaterial()
+    assert binding


### PR DESCRIPTION
## Summary
- remove legacy preview override and normalize per-renderer texture formats
- fix MaterialX float wiring and add workflow coverage in USD tests
- update docs for texture format overrides

## Testing
- python -m pytest